### PR TITLE
Fix a handful of PlanetWars issues

### DIFF
--- a/09 - Lab - PlanetWars/sample/PlanetWars/bots/OneMove.py
+++ b/09 - Lab - PlanetWars/sample/PlanetWars/bots/OneMove.py
@@ -2,9 +2,8 @@ class OneMove(object):
 
 	def update(self, gameinfo):
 
-		if gameinfo._my_planets and gameinfo._not_my_planets:
-			# print(gameinfo.my_planets)
-			src = list(gameinfo._my_planets.values())[0]
-			dest = list(gameinfo._not_my_planets.values())[0]
-			gameinfo.planet_order(src, dest, src.num_ships)
-			gameinfo.log("I'll send %d ships from planet %s to planet %s" % (src.num_ships, src, dest))
+		if gameinfo._my_planets() and gameinfo._not_my_planets():
+			src = list(gameinfo._my_planets().values())[0]
+			dest = list(gameinfo._not_my_planets().values())[0]
+			gameinfo.planet_order(src, dest, src.ships)
+			#gameinfo.log("I'll send %d ships from planet %s to planet %s" % (src.ships, src, dest))

--- a/09 - Lab - PlanetWars/sample/PlanetWars/planet_wars.py
+++ b/09 - Lab - PlanetWars/sample/PlanetWars/planet_wars.py
@@ -84,9 +84,10 @@ class PlanetWarsGame():
 				sum_of_planets[1] += planet.y
 				if planet.owner == player.ID:
 					planets_by_player[player.ID].append(planet)
-					sum_of_owned_planets[0] += planet.x
-					sum_of_owned_planets[1] += planet.y
-					count_of_owned_planets += 1
+					if planet.owner != NEUTRAL_ID:
+						sum_of_owned_planets[0] += planet.x
+						sum_of_owned_planets[1] += planet.y
+						count_of_owned_planets += 1
 			if not player.ID in planets_by_player.keys():
 				players_to_be_spawned.append(player.ID)
 		unowned_planets = planets_by_player.pop(NEUTRAL_ID)
@@ -96,9 +97,9 @@ class PlanetWarsGame():
 		for playerID in players_to_be_spawned:
 			if count_of_owned_planets == 0:
 				centroid_of_owned_planets[0] = sum_of_planets[0] / \
-					count_of_owned_planets
-				centroid_of_owned_planets[1] = sum_of_planets[0] / \
-					count_of_owned_planets
+					len(self.planets)
+				centroid_of_owned_planets[1] = sum_of_planets[1] / \
+					len(self.planets)
 			else:
 				centroid_of_owned_planets[0] = sum_of_owned_planets[0] / \
 					count_of_owned_planets

--- a/09 - Lab - PlanetWars/sample/PlanetWars/planet_wars_draw.py
+++ b/09 - Lab - PlanetWars/sample/PlanetWars/planet_wars_draw.py
@@ -235,7 +235,7 @@ class PlanetWarsWindow(pyglet.window.Window):
 
 		#load the background and scale it to the widnow size
 		
-		self.bg = pyglet.sprite.Sprite(pyglet.image.load(pathlib.PurePath().joinpath(".\\images\\space.jpg")))
+		self.bg = pyglet.sprite.Sprite(pyglet.image.load(pathlib.PurePath().joinpath("./images/space.jpg")))
 		self.bg.scale_x = self.width / self.bg.image.width
 		self.bg.scale_y = self.height / self.bg.image.height
 		#load the global UI elements (FPS counter, etc.)


### PR DESCRIPTION
- Fix running PlanetWars on Unix (one Microsoft-y path left over)
- Fix player spawning logic so it spreads players appropriately (closes #1)
- Fix incorrect use of `Player` fields in `OneMove` so it runs without errors